### PR TITLE
Решение проблемы с экспоненциальным видом ClientID

### DIFF
--- a/2. upload_data_to_clickhouse.ipynb
+++ b/2. upload_data_to_clickhouse.ipynb
@@ -318,6 +318,8 @@
     }
    ],
    "source": [
+    "hits_df['ClientID'] = hits_df['ClientID'].astype('uint64')\n",
+    "\n",
     "hits_df.head()"
    ]
   },


### PR DESCRIPTION
Столкнулся с проблемой ошибок на этапе загрузки .csv логов в базу ClickHouse. Причиной оказалось то, что почему-то в полученных логах просмотров Метрики ClientID был в экспоненциальном формате. Проблема решилась предварительным преобразованием этого столбца через astype().